### PR TITLE
make stable version 1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: 2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de
 
 build:
+  skip: True # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 requirements:
@@ -30,6 +31,7 @@ test:
     - pip
   commands:
     - pip check
+    - pytest ../tests
 
 about:
   home: https://pypi.org/project/pytest-json-report/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,17 +12,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
     - pytest >=3.8.0
     - pytest-metadata
-    - python >=3.6
+    - python 
 
 test:
   imports:
@@ -31,8 +29,16 @@ test:
 about:
   home: https://pypi.org/project/pytest-json-report/
   summary: A pytest plugin to report test results as JSON files
+  description: |
+    A pytest plugin to report test results as JSON files
+
+    It can report a summary, test details, captured output, logs, exception tracebacks and more. 
+    Additionally, you can use the available fixtures and hooks to add metadata and customize the report as you like.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://github.com/numirias/pytest-json-report
+  dev_url: https://github.com/numirias/pytest-json-report
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   host:
     - pip
+    - wheel
     - python
   run:
     - pytest >=3.8.0
@@ -25,6 +26,10 @@ requirements:
 test:
   imports:
     - pytest_jsonreport
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://pypi.org/project/pytest-json-report/


### PR DESCRIPTION
pytest-json-report 1.5.0

**Destination channel:** defaults

### Links

- [PKG-2654](https://anaconda.atlassian.net/browse/PKG-2654) 
- [Upstream repository](https://github.com/numirias/pytest-json-report)
- [Upstream changelog/diff](https://github.com/numirias/pytest-json-report/releases/tag/v1.5.0)

### Explanation of changes:
- clean up recipe and get it on main


[PKG-2654]: https://anaconda.atlassian.net/browse/PKG-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ